### PR TITLE
chore: update @bucketeer/js-client-sdk to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Bucketeer Team",
   "license": "MIT",
   "dependencies": {
-    "@bucketeer/js-client-sdk": "2.3.0"
+    "@bucketeer/js-client-sdk": "2.3.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1",


### PR DESCRIPTION
Bumped the @bucketeer/js-client-sdk dependency from version 2.3.0 to 2.3.1 for latest features and fixes.